### PR TITLE
INSIDE_JTOC-6631 【内部】GitHub Actionsを用いて、チェックがついてないコメントが含まれるPRをFailedにする

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,7 @@
   name: Merge-Branch-Checker
   entry: merge-branch-checker
   language: python
+- id: pr-status-checker
+  name: Pr-Status-Checker
+  entry: pr-status-checker
+  language: python

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -41,7 +41,7 @@ class PRStatusChecker:
 
     @classmethod
     def _get_source_branch(cls) -> str | None:
-        """マージメッセージからブランチ名を抽出"""
+        """マージ元のブランチ名取得"""
         if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge "):
             print("マージ処理中ではありません。スキップします。")
             return None

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -44,12 +44,12 @@ class PRStatusChecker:
     @classmethod
     def _get_source_branch(cls) -> str | None:
         """マージ元のブランチ名取得"""
-        print(os.environ.get("GIT_REFLOG_ACTION", ""))
-        print("")
         if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge "):
             return None
 
-        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge origin/")
+        print(os.environ.get("GIT_REFLOG_ACTION", ""))
+        print("")
+        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge ")
         return merged_branch_name
 
     @classmethod

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -75,10 +75,8 @@ class PRStatusChecker:
         # GitHub CLIの存在確認
         if os.name == "posix":
             exist_check_command = "which"
-            print("check command is :", exist_check_command)
         else:
             exist_check_command = "where.exe"
-            print("check command is :", exist_check_command)
 
         if subprocess.run([exist_check_command, "gh"], capture_output=True).returncode != 0:
             print("エラー: GitHub CLI (gh) がインストールされていません")

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -10,7 +10,7 @@ from pathlib import Path
 class PRStatusChecker:
     @classmethod
     def check_pr_status(cls) -> int:
-        print("GitHub PR Checker を開始します...", datetime.now().isoformat())
+        print("GitHub PR Checker を開始します...")
 
         time.sleep(3)
         try:
@@ -134,10 +134,6 @@ class PRStatusChecker:
         """PRのコミットが全てFMs社員のものか判定"""
         results = cls._run_command(["gh", "pr", "view", pr_number, "--json", "commits"])
         commits = json.loads(results)["commits"]
-
-        print("###")
-        print(commits)
-
         commit_author_emails = []
         for commit in commits:
             if commit["messageHeadline"] and commit["messageHeadline"].find("Merge"):

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -170,7 +170,7 @@ class PRStatusChecker:
         print("初めのコミット")
         print(first_commit_sha)
 
-        commiter_email = cls._run_command(["git", "show", "-s", "--format=$ae", first_commit_sha])
+        commiter_email = cls._run_command(["git", "show", "-s", "--format=%ae", first_commit_sha])
 
         print("email")
         print(commiter_email)

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -47,7 +47,7 @@ class PRStatusChecker:
     @classmethod
     def _run_command(cls, command: list) -> str:
         """コマンドを実行して結果を返す"""
-        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        result = subprocess.run(command, capture_output=True, text=True, check=True, shell=True)
         return result.stdout.strip()
 
     @classmethod

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -141,25 +141,34 @@ class PRStatusChecker:
     @classmethod
     def is_fms_member(cls, feature_branch: str, base_branch: str) -> bool:
         """PRのコミットの1番初めがFMs社員のコミットか確認"""
-        first_commit_sha = cls._run_command(
-            [
-                "git",
-                "log",
-                "--reverse",
-                "--format='%H'",
-                f"origin/{base_branch}..origin/{feature_branch}",
-                "|",
-                "head",
-                "-n",
-                "1",
-            ]
-        )
 
-        if first_commit_sha.startswith("fatal"):
+        try:
+            commit_shas = cls._run_command(
+                [
+                    "git",
+                    "log",
+                    "--reverse",
+                    "--format='%H'",
+                    f"origin/{base_branch}..origin/{feature_branch}",
+                ]
+            )
+        except Exception as e:
+            print("コミット履歴取得時に問題が発生しました。", e)
+            return False
+
+        if commit_shas.startswith("fatal"):
             print("feature branch", feature_branch)
             print("base brabch", base_branch)
             print("PRのコミットを取得できませんでした。")
             return False
+
+        print("コミットshaリスト")
+        print(commit_shas)
+
+        first_commit_sha = commit_shas.splitlines()[0]
+
+        print("初めのコミット")
+        print(first_commit_sha)
 
         commiter_email = cls._run_command(["git", "show", "-s", "--format=$ae", first_commit_sha])
 

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -129,6 +129,9 @@ class PRStatusChecker:
         results = cls._run_command(["gh", "pr", "view", pr_number, "--json", "commits"])
         commits = json.loads(results)["commits"]
 
+        print("###")
+        print(commits)
+
         commit_author_emails = []
         for commit in commits:
             # parentsの数が1より大きい場合はマージコミットなのでスキップ

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -47,7 +47,7 @@ class PRStatusChecker:
     @classmethod
     def _run_command(cls, command: list) -> str:
         """コマンドを実行して結果を返す"""
-        result = subprocess.run(command, capture_output=True, text=True, check=True, shell=True)
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
         return result.stdout.strip()
 
     @classmethod
@@ -148,7 +148,7 @@ class PRStatusChecker:
                     "git",
                     "log",
                     "--reverse",
-                    "--format='%H'",
+                    "--format=%H",
                     f"origin/{base_branch}..origin/{feature_branch}",
                 ]
             )

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -69,7 +69,7 @@ class PRStatusChecker:
         return cls._run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
 
     @classmethod
-    def _check_gh_cli_availability(cls) -> bool:
+    def _check_github_cli_availability(cls) -> bool:
         """GitHub CLIが利用可能か確認"""
         # GitHub CLIの存在確認
         if os.name == "posix":
@@ -95,7 +95,7 @@ class PRStatusChecker:
     def _check_pr_status(cls, branch_name: str) -> bool:
         """PRのステータスをチェック"""
         # GitHub CLIのチェック
-        if not cls._check_gh_cli_availability():
+        if not cls._check_github_cli_availability():
             return False
 
         print(f"\nブランチ '{branch_name}' のPRを検索しています...")

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -69,19 +69,7 @@ class PRStatusChecker:
     @classmethod
     def _get_base_branch(cls) -> str | None:
         """マージ先のブランチ名取得"""
-        git_dir = cls._run_command(["git", "rev-parse", "--git-dir"])
-        merge_msg_file = Path(os.getcwd()) / Path(git_dir) / "MERGE_MSG"
-
-        if not merge_msg_file.exists():
-            return None
-
-        merge_msg = merge_msg_file.read_text()
-
-        # マージ先のブランチ名を抽出
-        match = re.search(r"into\\s+'([^']+)'", merge_msg)
-        if match:
-            return match.group(1)
-        return None
+        return cls._run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
 
     @classmethod
     def _check_gh_cli(cls) -> bool:

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -44,12 +44,12 @@ class PRStatusChecker:
     @classmethod
     def _get_source_branch(cls) -> str | None:
         """マージ元のブランチ名取得"""
-        if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge "):
+        if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge origin/"):
             return None
 
         print(os.environ.get("GIT_REFLOG_ACTION", ""))
         print("")
-        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge ")
+        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge origin/")
         return merged_branch_name
 
     @classmethod

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -45,7 +45,6 @@ class PRStatusChecker:
     def _get_source_branch(cls) -> str | None:
         """マージ元のブランチ名取得"""
         if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge "):
-            print("マージ処理中ではありません。スキップします。")
             return None
 
         merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge ")

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -97,7 +97,7 @@ class PRStatusChecker:
             pr_number = prs[0]["number"]
 
             is_fms_member = cls.is_fms_member(str(pr_number))
-            if not is_fms_member:
+            if not is_fms_member: # FMs社員ではない場合はステータスチェックを常にTrueで通過
                 return True
 
             print(f"PR #{pr_number} のステータスチェックを確認しています...")
@@ -131,15 +131,11 @@ class PRStatusChecker:
 
     @classmethod
     def is_fms_member(cls, pr_number: str):
-        """PRのコミットが全てFMs社員のものか判定"""
+        """PRのコミットの1番初めがFMs社員のコミットか確認"""
         results = cls._run_command(["gh", "pr", "view", pr_number, "--json", "commits"])
         commits = json.loads(results)["commits"]
-        commit_author_emails = []
         for commit in commits:
             if commit["messageHeadline"] and commit["messageHeadline"].find("Merge"):
                 continue
 
-            for author in commit["authors"]:
-                commit_author_emails.append(author["email"])
-
-        return all([email for email in commit_author_emails if email.find("@fullmarks.co.jp")])
+            return commit["authors"][0]["email"].find("@fullmarks.co.jp")

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -162,10 +162,7 @@ class PRStatusChecker:
             result = cls._run_command(["git", "show", "-s", "--format=%P#%ae", commit_sha])
 
             parent_commits, commiter_email = result.split("#")
-            print("email :", commiter_email)
-            print("commits")
-            print(parent_commits)
-            if len(parent_commits.split()) > 1:
+            if len(parent_commits.split()) > 1:  # マージコミットはスキップ
                 continue
 
             return "@fullmarks.co.jp" in commiter_email

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -134,8 +134,7 @@ class PRStatusChecker:
 
         commit_author_emails = []
         for commit in commits:
-            # parentsの数が1より大きい場合はマージコミットなのでスキップ
-            if len(commit["parents"]) > 1:
+            if commit["messageHeadline"].find("Merge"):
                 continue
 
             for author in commit["authors"]:

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import json
+import time
 from datetime import datetime
 
 
@@ -9,6 +10,7 @@ class PRStatusChecker:
     def check_pr_status(cls) -> int:
         print("GitHub PR Checker を開始します...", datetime.now().isoformat())
 
+        time.sleep(3)
         try:
             # ブランチ名の抽出
             branch_name = cls._get_source_branch()

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -1,0 +1,138 @@
+import os
+import subprocess
+import json
+from datetime import datetime
+
+
+class PRStatusChecker:
+    @classmethod
+    def check_pr_status(cls) -> int:
+        print("GitHub PR Checker を開始します...", datetime.now().isoformat())
+
+        try:
+            # ブランチ名の抽出
+            branch_name = cls._get_source_branch()
+            if not branch_name:
+                print("マージ中ではありません。スキップします。")
+                cls.reset_to_before_merge()
+                return 1
+
+            # PRのステータスチェック
+            success = cls._check_pr_status(branch_name)
+            if not success:
+                print("\nPRの概要欄を確認後チェックをつけてください。")
+                print("\nPushを中断します。")
+                cls.reset_to_before_merge()
+                return 1
+
+            print("\nPRのステータスはSUCCESSです。Pushします。")
+            return 0
+
+        except Exception as e:
+            print(f"予期せぬエラーが発生しました: {e}")
+            cls.reset_to_before_merge()
+            return 1
+
+    @classmethod
+    def _run_command(cls, command: list) -> str:
+        """コマンドを実行して結果を返す"""
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+
+    @classmethod
+    def _get_source_branch(cls) -> str | None:
+        """マージメッセージからブランチ名を抽出"""
+        if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge "):
+            print("マージ処理中ではありません。スキップします。")
+            return None
+
+        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge ")
+        return merged_branch_name
+
+    @classmethod
+    def _check_gh_cli(cls) -> bool:
+        """GitHub CLIが利用可能か確認"""
+        # GitHub CLIの存在確認
+        if subprocess.run(["which", "gh"], capture_output=True).returncode != 0:
+            print("エラー: GitHub CLI (gh) がインストールされていません")
+            cls.reset_to_before_merge()
+            return False
+
+        # 認証状態の確認
+        if subprocess.run(["gh", "auth", "status"], capture_output=True).returncode != 0:
+            print("エラー: GitHub CLIが認証されていません")
+            print("gh auth login を実行してログインしてください")
+            cls.reset_to_before_merge()
+            return False
+
+        return True
+
+    @classmethod
+    def _check_pr_status(cls, branch_name: str) -> bool:
+        """PRのステータスをチェック"""
+        # GitHub CLIのチェック
+        if not cls._check_gh_cli():
+            return False
+
+        print(f"\nブランチ '{branch_name}' のPRを検索しています...")
+
+        try:
+            # PRの検索
+            pr_list = cls._run_command(["gh", "pr", "list", "--head", branch_name, "--json", "number"])
+            prs = json.loads(pr_list)
+
+            if not prs:
+                print(f"警告: ブランチ {branch_name} のPRが見つかりません")
+                return True
+
+            pr_number = prs[0]["number"]
+
+            is_fms_member = cls.is_fms_member(str(pr_number))
+            if not is_fms_member:
+                return True
+
+            print(f"PR #{pr_number} のステータスチェックを確認しています...")
+
+            # ステータスチェックの取得
+            status_json = cls._run_command(["gh", "pr", "view", str(pr_number), "--json", "statusCheckRollup"])
+            status_data = json.loads(status_json).get("statusCheckRollup", None)
+
+            if not status_data:
+                return True
+
+            latest_conclusion = max(
+                status_data, key=lambda x: datetime.fromisoformat(x["completedAt"].replace("Z", ""))
+            ).get("conclusion", False)
+
+            # FAILURE以外（SKIPも）はSUCCESSとみなす
+            return not latest_conclusion == "FAILURE"
+
+        except subprocess.CalledProcessError as e:
+            print(f"GitHub CLIコマンドの実行中にエラーが発生: {e}")
+            return False
+
+    @classmethod
+    def reset_to_before_merge(cls):
+        """差分を破棄して前の作業ブランチに戻る"""
+        print("git reset --mergeを実行してgit statusリセット後に再試行してください。")
+
+        cls._run_command(["git", "reset", "--merge"])
+
+        cls._run_command(["git", "checkout", "-"])
+
+    @classmethod
+    def is_fms_member(cls, pr_number: str):
+        """PRのコミットが全てFMs社員のものか判定"""
+        results = cls._run_command(["gh", "pr", "view", pr_number, "--json", "commits"])
+        commits = json.loads(results)["commits"]
+
+        commit_author_emails = []
+        for commit in commits:
+            # parentsの数が1より大きい場合はマージコミットなのでスキップ
+            if len(commit["parents"]) > 1:
+                continue
+
+            for author in commit["authors"]:
+                commit_author_emails.append(author["email"])
+
+        return all([email for email in commit_author_emails if email.find("@fullmarks.co.jp")])

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -16,8 +16,7 @@ class PRStatusChecker:
             branch_name = cls._get_source_branch()
             if not branch_name:
                 print("マージ中ではありません。スキップします。")
-                cls.reset_to_before_merge()
-                return 1
+                return 0
 
             # PRのステータスチェック
             success = cls._check_pr_status(branch_name)

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -44,11 +44,12 @@ class PRStatusChecker:
     @classmethod
     def _get_source_branch(cls) -> str | None:
         """マージ元のブランチ名取得"""
+        print(os.environ.get("GIT_REFLOG_ACTION", ""))
+        print("")
         if not os.environ.get("GIT_REFLOG_ACTION", "").startswith("merge "):
             return None
 
-        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge ")
-        print("ブランチ名：", merged_branch_name)
+        merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge origin/")
         return merged_branch_name
 
     @classmethod

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -48,6 +48,7 @@ class PRStatusChecker:
             return None
 
         merged_branch_name = os.environ.get("GIT_REFLOG_ACTION", "").removeprefix("merge ")
+        print("ブランチ名：", merged_branch_name)
         return merged_branch_name
 
     @classmethod

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -121,9 +121,9 @@ class PRStatusChecker:
             if not status_logs:
                 return True
 
-            latest_conclusion = max(
-                status_logs, key=lambda status_log: datetime.fromisoformat(status_log["completedAt"].replace("Z", ""))
-            ).get("conclusion", "FAILURE")
+            latest_conclusion = max(status_logs, key=lambda status_log: status_log["completedAt"]).get(
+                "conclusion", "FAILURE"
+            )
 
             # FAILURE以外（SKIPも）はSUCCESSとみなす
             return not latest_conclusion == "FAILURE"

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -162,7 +162,10 @@ class PRStatusChecker:
             result = cls._run_command(["git", "show", "-s", "--format=%P#%ae", commit_sha])
 
             parent_commits, commiter_email = result.split("#")
-            if parent_commits.split() > 1:
+            print("email :", commiter_email)
+            print("commits")
+            print(parent_commits)
+            if len(parent_commits.split()) > 1:
                 continue
 
             return "@fullmarks.co.jp" in commiter_email

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -165,11 +165,14 @@ class PRStatusChecker:
         print("コミットshaリスト")
         print(commit_shas)
 
-        first_commit_sha = commit_shas.splitlines()[0]
+        first_commit_sha = commit_shas.splitlines()[0].strip("'")
 
         print("初めのコミット")
         print(first_commit_sha)
 
         commiter_email = cls._run_command(["git", "show", "-s", "--format=$ae", first_commit_sha])
+
+        print("email")
+        print(commiter_email)
 
         return "@fullmarks.co.jp" in commiter_email

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -73,7 +73,14 @@ class PRStatusChecker:
     def _check_gh_cli(cls) -> bool:
         """GitHub CLIが利用可能か確認"""
         # GitHub CLIの存在確認
-        if subprocess.run(["which", "gh"], capture_output=True).returncode != 0:
+        if os.name == "posix":
+            exist_check_command = "which"
+            print("check command is :", exist_check_command)
+        else:
+            exist_check_command = "where.exe"
+            print("check command is :", exist_check_command)
+
+        if subprocess.run([exist_check_command, "gh"], capture_output=True).returncode != 0:
             print("エラー: GitHub CLI (gh) がインストールされていません")
             cls.reset_to_before_merge()
             return False

--- a/code_checker/pr_status_checker.py
+++ b/code_checker/pr_status_checker.py
@@ -134,7 +134,7 @@ class PRStatusChecker:
 
         commit_author_emails = []
         for commit in commits:
-            if commit["messageHeadline"].find("Merge"):
+            if commit["messageHeadline"] and commit["messageHeadline"].find("Merge"):
                 continue
 
             for author in commit["authors"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ merged-code-checker = 'code_checker.source_code_checker:SourceCodeChecker.check_
 batch-yaml-sorter = 'code_checker.batch_yaml_checker:BatchYamlChecker.sort_batch_yaml'
 batch-yaml-checker = 'code_checker.batch_yaml_checker:BatchYamlChecker.check_staged_batch_yaml_files'
 merge-branch-checker = 'code_checker.branch_checker:BranchChecker.check_merge_branch'
+pr-status-checker = 'code_checker.pr_status_checker:PRStatusChecker.check_pr_status'
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 対応内容
- 新規フックを追加（pr-status-checker）

## 処理内容
- prepare-commit-msg（コミットメッセージの準備）で起動
- マージコミットであり、かつFMs社員の場合はgh（Github CLI）を使用してPRのステータスを確認する
- FAILUREの場合はコミットを中断し、それ以外はデフォルトでコミットを通す